### PR TITLE
fix: prevent computer score from increasing on tie rounds issue(#2)

### DIFF
--- a/script.js
+++ b/script.js
@@ -48,7 +48,9 @@ function playRound(humanChoice,computerChoice){
     else if(humanChoice === "SCISSORS" && computerChoice === "PAPER"){
         return result = 1;
     }
-    
+    else if(humanChoice === computerChoice){
+	return result = 2;
+    }
 }
 
 function playGame(){
@@ -62,10 +64,11 @@ function playGame(){
         if(round == true){
             humanScore++;
         }
-        else{
+	else if(round == 2){
+	}
+	else{
             computerScore++;
         }
-
         console.log("Your points: "+humanScore);
         console.log("Computer points: "+computerScore);
         


### PR DESCRIPTION
I noticed that the score of computer was increasing even if the round was ending in a tie. Then I checked that there was no logic for handling the case if the round ends in a tie. I added the bare minimum required logic for that. You did good on your code. I just fixed the little issue, now it updates the scores correctly.